### PR TITLE
DTL-5919 Checkout only necessary action directories

### DIFF
--- a/.github/workflows/reusable_cicd-npm-package-checks.yml
+++ b/.github/workflows/reusable_cicd-npm-package-checks.yml
@@ -64,10 +64,6 @@ jobs:
         with:
           github-token: ${{ steps.get-workflow-token.outputs.token }}
 
-      - name: Set Git Config
-        uses: ./gha-setup/actions/set-git-config-gha
-        continue-on-error: false
-
       - name: Update Branch from master
         uses: actions/github-script@v7
         id: update-branch

--- a/.github/workflows/reusable_cicd-npm-package-checks.yml
+++ b/.github/workflows/reusable_cicd-npm-package-checks.yml
@@ -54,6 +54,10 @@ jobs:
           path: gha-setup
           ref: master
           token: ${{ secrets.GHA_SETUP_ACCESS_TOKEN }}
+          sparse-checkout: |
+            actions/pull-request-check
+            actions/npm-package-checks
+            actions/npm-package-label-parser
 
       - name: Check Pull Request against defined rules
         uses: ./gha-setup/actions/pull-request-check
@@ -98,3 +102,7 @@ jobs:
       - name: Parse NPM Package Version
         id: npm-package-version
         uses: ./gha-setup/actions/npm-package-label-parser
+
+      # expect to fail
+      - name: Set Git Config
+        uses: ./gha-setup/actions/set-git-config-gha

--- a/.github/workflows/reusable_cicd-npm-package-checks.yml
+++ b/.github/workflows/reusable_cicd-npm-package-checks.yml
@@ -66,6 +66,7 @@ jobs:
 
       - name: Set Git Config
         uses: ./gha-setup/actions/set-git-config-gha
+        continue-on-error: false
 
       - name: Update Branch from master
         uses: actions/github-script@v7

--- a/.github/workflows/reusable_cicd-npm-package-checks.yml
+++ b/.github/workflows/reusable_cicd-npm-package-checks.yml
@@ -102,7 +102,3 @@ jobs:
       - name: Parse NPM Package Version
         id: npm-package-version
         uses: ./gha-setup/actions/npm-package-label-parser
-
-      # expect to fail
-      - name: Set Git Config
-        uses: ./gha-setup/actions/set-git-config-gha

--- a/.github/workflows/reusable_cicd-npm-package-checks.yml
+++ b/.github/workflows/reusable_cicd-npm-package-checks.yml
@@ -102,3 +102,6 @@ jobs:
       - name: Parse NPM Package Version
         id: npm-package-version
         uses: ./gha-setup/actions/npm-package-label-parser
+
+      - name: Set Git Config
+        uses: ./gha-setup/actions/set-git-config-gha

--- a/.github/workflows/reusable_cicd-npm-package-checks.yml
+++ b/.github/workflows/reusable_cicd-npm-package-checks.yml
@@ -64,6 +64,9 @@ jobs:
         with:
           github-token: ${{ steps.get-workflow-token.outputs.token }}
 
+      - name: Set Git Config
+        uses: ./gha-setup/actions/set-git-config-gha
+
       - name: Update Branch from master
         uses: actions/github-script@v7
         id: update-branch
@@ -102,6 +105,3 @@ jobs:
       - name: Parse NPM Package Version
         id: npm-package-version
         uses: ./gha-setup/actions/npm-package-label-parser
-
-      - name: Set Git Config
-        uses: ./gha-setup/actions/set-git-config-gha

--- a/.github/workflows/reusable_cicd-npm-package-publish.yml
+++ b/.github/workflows/reusable_cicd-npm-package-publish.yml
@@ -52,6 +52,8 @@ jobs:
           path: gha-setup
           ref: master
           token: ${{ secrets.GHA_SETUP_ACCESS_TOKEN }}
+          sparse-checkout: |
+            actions/set-git-config-gha
 
       - name: Set Git Config
         uses: ./gha-setup/actions/set-git-config-gha

--- a/.github/workflows/reusable_cicd-npm-package-test.yml
+++ b/.github/workflows/reusable_cicd-npm-package-test.yml
@@ -80,6 +80,10 @@ jobs:
           path: gha-setup
           ref: master
           token: ${{ secrets.GHA_SETUP_ACCESS_TOKEN }}
+          sparse-checkout: |
+            actions/platform/build-code
+            actions/platform/run-unit-tests
+            actions/dispatch-tests
 
       - name: Build Source
         uses: ./gha-setup/actions/platform/build-code
@@ -131,6 +135,9 @@ jobs:
           path: gha-setup
           ref: master
           token: ${{ secrets.GHA_SETUP_ACCESS_TOKEN }}
+          sparse-checkout: |
+            actions/platform/build-code
+            actions/platform/run-unit-tests
 
       - name: Build Source
         uses: ./gha-setup/actions/platform/build-code

--- a/.github/workflows/reusable_cicd-npm-publish.yml
+++ b/.github/workflows/reusable_cicd-npm-publish.yml
@@ -37,7 +37,7 @@ env:
 jobs:
   package-checks:
     name : Package Checks
-    uses: pipedrive-actions/github-actions-workflows/.github/workflows/reusable_cicd-npm-package-checks.yml@DTL-5919-checkout-only-necessary-action-directories-instead-of-whole-gha-setup
+    uses: pipedrive-actions/github-actions-workflows/.github/workflows/reusable_cicd-npm-package-checks.yml@master
     with:
       revision: ${{ inputs.revision }}
       runner: ${{ inputs.runner }}
@@ -46,7 +46,7 @@ jobs:
   package-test:
     needs: package-checks
     name: Package Test
-    uses: pipedrive-actions/github-actions-workflows/.github/workflows/reusable_cicd-npm-package-test.yml@DTL-5919-checkout-only-necessary-action-directories-instead-of-whole-gha-setup
+    uses: pipedrive-actions/github-actions-workflows/.github/workflows/reusable_cicd-npm-package-test.yml@master
     with:
       revision: ${{ needs.package-checks.outputs.revision }}
       supported_versions: ${{ inputs.supported_versions }}
@@ -60,7 +60,7 @@ jobs:
       - package-test
       - package-checks
     name: Package Publish
-    uses: pipedrive-actions/github-actions-workflows/.github/workflows/reusable_cicd-npm-package-publish.yml@DTL-5919-checkout-only-necessary-action-directories-instead-of-whole-gha-setup
+    uses: pipedrive-actions/github-actions-workflows/.github/workflows/reusable_cicd-npm-package-publish.yml@master
     with:
       revision: ${{inputs.revision }}
       version: ${{ needs.package-checks.outputs.version }}

--- a/.github/workflows/reusable_cicd-npm-publish.yml
+++ b/.github/workflows/reusable_cicd-npm-publish.yml
@@ -46,7 +46,7 @@ jobs:
   package-test:
     needs: package-checks
     name: Package Test
-    uses: pipedrive-actions/github-actions-workflows/.github/workflows/reusable_cicd-npm-package-test.yml@master
+    uses: pipedrive-actions/github-actions-workflows/.github/workflows/reusable_cicd-npm-package-test.yml@DTL-5919-checkout-only-necessary-action-directories-instead-of-whole-gha-setup
     with:
       revision: ${{ needs.package-checks.outputs.revision }}
       supported_versions: ${{ inputs.supported_versions }}
@@ -60,7 +60,7 @@ jobs:
       - package-test
       - package-checks
     name: Package Publish
-    uses: pipedrive-actions/github-actions-workflows/.github/workflows/reusable_cicd-npm-package-publish.yml@master
+    uses: pipedrive-actions/github-actions-workflows/.github/workflows/reusable_cicd-npm-package-publish.yml@DTL-5919-checkout-only-necessary-action-directories-instead-of-whole-gha-setup
     with:
       revision: ${{inputs.revision }}
       version: ${{ needs.package-checks.outputs.version }}

--- a/.github/workflows/reusable_cicd-npm-publish.yml
+++ b/.github/workflows/reusable_cicd-npm-publish.yml
@@ -37,7 +37,7 @@ env:
 jobs:
   package-checks:
     name : Package Checks
-    uses: pipedrive-actions/github-actions-workflows/.github/workflows/reusable_cicd-npm-package-checks.yml@master
+    uses: pipedrive-actions/github-actions-workflows/.github/workflows/reusable_cicd-npm-package-checks.yml@DTL-5919-checkout-only-necessary-action-directories-instead-of-whole-gha-setup
     with:
       revision: ${{ inputs.revision }}
       runner: ${{ inputs.runner }}


### PR DESCRIPTION
https://pipedrive.atlassian.net/browse/DTL-5919

Modified the workflows to checkout only necessary action directories

Tested that another action is not accessible: https://github.com/pipedrive/test-public-npm-module/actions/runs/11632268229/job/32395036702?pr=16#step:6:1

Validated publishing works: https://github.com/pipedrive/test-public-npm-module/actions/runs/11632411562/job/32395449782 (uses this revision: https://github.com/pipedrive-actions/github-actions-workflows/pull/2/commits/127edb5598f4490ea99eed75d09e2692fd35fda2)