### PR TITLE
CICDL-258: Add opt-in NPM Trusted Publishers (OIDC) support

### DIFF
--- a/.github/workflows/reusable_cicd-npm-package-checks.yml
+++ b/.github/workflows/reusable_cicd-npm-package-checks.yml
@@ -34,21 +34,21 @@ jobs:
       version: ${{ steps.npm-package-version.outputs.version }}
     steps:
       - name: Get Pipedrive GitHub Actions Bot Token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         id: get-workflow-token
         with:
-          app-id: ${{ vars.PD_PUBLIC_GHA_BOT_APPLICATION_ID }}
+          client-id: ${{ vars.PD_PUBLIC_GHA_BOT_APPLICATION_ID }}
           private-key: ${{ secrets.PD_PUBLIC_GHA_BOT_APPLICATION_PRIVATE_KEY_PEM }}
           owner: ${{ github.repository_owner }}
 
       - name: Checkout repo ${{ github.repository }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ steps.update-branch.outputs.result }}
           fetch-depth: 1
 
       - name: Checkout gha-setup
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: pipedrive/gha-setup
           path: gha-setup
@@ -65,7 +65,7 @@ jobs:
           github-token: ${{ steps.get-workflow-token.outputs.token }}
 
       - name: Update Branch from master
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         id: update-branch
         env:
           HEAD_REF: ${{ github.event.pull_request.head.ref }}

--- a/.github/workflows/reusable_cicd-npm-package-checks.yml
+++ b/.github/workflows/reusable_cicd-npm-package-checks.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/create-github-app-token@v3
         id: get-workflow-token
         with:
-          client-id: ${{ vars.PD_PUBLIC_GHA_BOT_APPLICATION_ID }}
+          client-id: ${{ vars.PD_PUBLIC_GHA_BOT_CLIENT_ID }}
           private-key: ${{ secrets.PD_PUBLIC_GHA_BOT_APPLICATION_PRIVATE_KEY_PEM }}
           owner: ${{ github.repository_owner }}
 

--- a/.github/workflows/reusable_cicd-npm-package-publish.yml
+++ b/.github/workflows/reusable_cicd-npm-package-publish.yml
@@ -50,14 +50,14 @@ jobs:
             exit 1
           fi
       - name: Checkout ${{ github.repository }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.revision || github.ref }}
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
           persist-credentials: false
       - name: Checkout gha-setup
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: pipedrive/gha-setup
           path: gha-setup
@@ -71,7 +71,7 @@ jobs:
         uses: pipedrive-actions/github-actions-workflows/actions/setup-node@master
       - name: Add Changelog Record
         if: ${{github.event.pull_request.user.login == 'dependabot[bot]'}}
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
         with:
@@ -106,10 +106,10 @@ jobs:
           echo "Tagging merge commit with ${VERSION}"
           git tag "${VERSION}"
       - name: Get Pipedrive GitHub Actions Bot Token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         id: get-workflow-token
         with:
-          app-id: ${{ vars.PD_PUBLIC_GHA_BOT_APPLICATION_ID }}
+          client-id: ${{ vars.PD_PUBLIC_GHA_BOT_APPLICATION_ID }}
           private-key: ${{ secrets.PD_PUBLIC_GHA_BOT_APPLICATION_PRIVATE_KEY_PEM }}
           owner: ${{ github.repository_owner }}
       - name: Push to GitHub

--- a/.github/workflows/reusable_cicd-npm-package-publish.yml
+++ b/.github/workflows/reusable_cicd-npm-package-publish.yml
@@ -179,6 +179,7 @@ jobs:
       - name: Publish to NPM
         uses: pipedrive/gha-command-retry@v3
         env:
+          ## Not set NPM_TOKEN when using trusted publisher because in that flow that token is not needed
           NPM_TOKEN: ${{ !inputs.use_trusted_publisher && secrets.NPM_PUBLIC_PUBLISH_TOKEN || '' }}
           VERSION: ${{ inputs.version }}
           PUBLISH_ACCESS: ${{ steps.read-package-json.outputs.publish_access }}

--- a/.github/workflows/reusable_cicd-npm-package-publish.yml
+++ b/.github/workflows/reusable_cicd-npm-package-publish.yml
@@ -1,38 +1,38 @@
 name: NPM Package Publish
 on:
   workflow_call:
-  # This workflow will be trigger in the context of pull_request labeled event
+    # This workflow will be trigger in the context of pull_request labeled event
     inputs:
       revision:
         description: The branch, tag or commit hash to checkout.
         type: string
         required: false
-
       runner:
         description: Label for GitHub-hosted runner to use. Defaults to ubuntu-latest
         type: string
         required: false
         default: ubuntu-latest
-
       version:
         description: The version to bump to. Defaults to patch. Possible option [<newversion> | major | minor | patch | premajor | preminor | prepatch | prerelease | from-git]
         type: string
         required: false
         default: patch
-
       publish_timeout_seconds:
         description: Seconds to wait before the attempt to publish the package times outs. Defaults to 180
         type: number
         default: 180
         required: false
-
+      use_trusted_publisher:
+        description: Use NPM Trusted Publishers (OIDC) instead of NPM token. Requires trusted publisher registered on npmjs.com.
+        type: boolean
+        required: false
+        default: false
     secrets:
       NPM_PUBLIC_PUBLISH_TOKEN:
         description: NPM token to use for publishing
         required: true
       PD_PUBLIC_GHA_BOT_APPLICATION_PRIVATE_KEY_PEM:
-        required: true      
-
+        required: true
 jobs:
   package-publish:
     runs-on: ${{ inputs.runner }}
@@ -44,7 +44,6 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
           persist-credentials: false
-
       - name: Checkout gha-setup
         uses: actions/checkout@v4
         with:
@@ -54,52 +53,30 @@ jobs:
           token: ${{ secrets.GHA_SETUP_ACCESS_TOKEN }}
           sparse-checkout: |
             actions/set-git-config-gha
-
       - name: Set Git Config
         uses: ./gha-setup/actions/set-git-config-gha
-
       - name: Setup Node.js
         uses: pipedrive-actions/github-actions-workflows/actions/setup-node@master
-
       - name: Add Changelog Record
         if: ${{github.event.pull_request.user.login == 'dependabot[bot]'}}
         uses: actions/github-script@v7
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
         with:
-          script: |
-            const fs = require('fs');
-            if (!fs.existsSync('CHANGELOG.md')) {
-              core.info('Repository without CHANGELOG.md');
-              return;
-              
-            }
-            
-            const regexp = /##\s\[Unreleased\](\n|###\s.*|-\s.*)+/
-            const current = fs.readFileSync('CHANGELOG.md', 'utf8');
-            if (regexp.test(current) ) {
-              const updated = current.replace(regexp, `## [Unreleased]\n\n### Changed\n\n- ${process.env.PR_TITLE}\n\n`)
-            
-              fs.writeFileSync('CHANGELOG.md', updated)
-              await exec.exec("git", ["commit", "-a", "-m 'Update CHANGELOG'","--no-verify"])
-            } else {
-              core.info("Changelog doesn't follow the expected format : ${regexp}")
-            }
-
+          script: "const fs = require('fs');\nif (!fs.existsSync('CHANGELOG.md')) {\n  core.info('Repository without CHANGELOG.md');\n  return;\n  \n}\n\nconst regexp = /##\\s\\[Unreleased\\](\\n|###\\s.*|-\\s.*)+/\nconst current = fs.readFileSync('CHANGELOG.md', 'utf8');\nif (regexp.test(current) ) {\n  const updated = current.replace(regexp, `## [Unreleased]\\n\\n### Changed\\n\\n- ${process.env.PR_TITLE}\\n\\n`)\n\n  fs.writeFileSync('CHANGELOG.md', updated)\n  await exec.exec(\"git\", [\"commit\", \"-a\", \"-m 'Update CHANGELOG'\",\"--no-verify\"])\n} else {\n  core.info(\"Changelog doesn't follow the expected format : ${regexp}\")\n}\n"
       - name: Bump Version
         id: bump-version
         env:
           VERSION: ${{ inputs.version }}
         run: |
           echo "bump NPM module version: ${VERSION}"
-          
+
           npm version "${VERSION}" --preid rc --commit-hooks false --git-tag-version=false
           git add package.json package-lock.json
-          
+
           semVersion=$(jq -r .version package.json)
           git commit -m "${semVersion}" --no-verify
           echo "version=v${semVersion}" >> "${GITHUB_OUTPUT}"
-
       - name: Merge to BaseBranch
         env:
           GITHUB_BASE_REF: ${{ github.event.pull_request.base.ref }}
@@ -110,14 +87,12 @@ jobs:
           git fetch origin "${GITHUB_BASE_REF}"
           git checkout "${GITHUB_BASE_REF}"
           git merge --no-ff "${REVISION}" -m "Release ${VERSION} from PR #${PR_NUMBER}"
-
       - name: Create git TAG
         env:
           VERSION: ${{ steps.bump-version.outputs.version }}
         run: |
-            echo "Tagging merge commit with ${VERSION}"
-            git tag "${VERSION}"
-
+          echo "Tagging merge commit with ${VERSION}"
+          git tag "${VERSION}"
       - name: Get Pipedrive GitHub Actions Bot Token
         uses: actions/create-github-app-token@v1
         id: get-workflow-token
@@ -125,30 +100,13 @@ jobs:
           app-id: ${{ vars.PD_PUBLIC_GHA_BOT_APPLICATION_ID }}
           private-key: ${{ secrets.PD_PUBLIC_GHA_BOT_APPLICATION_PRIVATE_KEY_PEM }}
           owner: ${{ github.repository_owner }}
-
       - name: Push to GitHub
         env:
           GITHUB_BASE_REF: ${{ github.event.pull_request.base.ref }}
           VERSION: ${{ steps.bump-version.outputs.version }}
           REPO: ${{ github.repository }}
           GITHUB_TOKEN: ${{ steps.get-workflow-token.outputs.token }}
-        run: |
-          git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/${REPO}.git
-          if ! git push origin "${GITHUB_BASE_REF}" --tags --no-verify
-          then
-              echo "Deleting ${VERSION} tag from remote."
-              git push --delete origin "${VERSION}"
-              
-              _errorMessage="
-              Failed to push to origin branch ${GITHUB_BASE_REF}.
-              Please check branch protection configuration in GitHub https://github.com/pipedrive/${params.REPO_NAME}/settings/branches
-              See https://pipedrive.atlassian.net/wiki/spaces/SD/pages/231178497/How+to+publish+NPM+modules#HowtopublishNPMmodules-Setup for more details.
-              "
-            
-              echo "::error::${_errorMessage}"
-              exit 1
-          fi
-
+        run: "git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/${REPO}.git\nif ! git push origin \"${GITHUB_BASE_REF}\" --tags --no-verify\nthen\n    echo \"Deleting ${VERSION} tag from remote.\"\n    git push --delete origin \"${VERSION}\"\n    \n    _errorMessage=\"\n    Failed to push to origin branch ${GITHUB_BASE_REF}.\n    Please check branch protection configuration in GitHub https://github.com/pipedrive/${params.REPO_NAME}/settings/branches\n    See https://pipedrive.atlassian.net/wiki/spaces/SD/pages/231178497/How+to+publish+NPM+modules#HowtopublishNPMmodules-Setup for more details.\n    \"\n  \n    echo \"::error::${_errorMessage}\"\n    exit 1\nfi\n"
       - name: Create .npmrc for publishing
         shell: bash
         run: |
@@ -161,7 +119,6 @@ jobs:
             echo "@pipedrive:registry=https://registry.npmjs.org"
             echo "always-auth=true"
           } > .npmrc
-
       - name: Read package.json
         id: read-package-json
         shell: bash
@@ -169,11 +126,10 @@ jobs:
           PUBLISH_ACCESS=$(jq -r .publishConfig.access package.json)
           echo "PUBLISH_ACCESS=${PUBLISH_ACCESS}"
           echo "publish_access=${PUBLISH_ACCESS}" >> "$GITHUB_OUTPUT"
-          
+
           PACKAGE_NAME=$(jq -r .name package.json)
           echo "PACKAGE_NAME=${PACKAGE_NAME}"
           echo "package_name=${PACKAGE_NAME}" >> "$GITHUB_OUTPUT"
-
       - name: Publish to NPM
         uses: pipedrive/gha-command-retry@v3
         env:
@@ -184,22 +140,14 @@ jobs:
           timeout_seconds: ${{ inputs.publish_timeout_seconds }}
           max_attempts: 3
           shell: bash
-          command: |
-            # shellcheck disable=SC2016      
-            distTag=$([[ ${VERSION} == pre* ]] && echo "--tag=next" || echo "")
-            access=$([[ ${PUBLISH_ACCESS} = 'public' ]] && echo "--access=public" || echo "--access=restricted")
-            accessMessage=$([[ ${PUBLISH_ACCESS} = 'public' ]] && echo "public" || echo "private")
-            tagMessage=$([[ ${VERSION} == pre* ]] && echo " with tag next" || echo "")
-            
-            echo "Publishing new ${accessMessage} NPM module version${tagMessage}"
-            # Cannot use double quoting because of a bug in npm that assumes the "" as input
-            # shellcheck disable=SC2086
-            npm publish ${distTag} ${access}
-
+          command: "# shellcheck disable=SC2016      \ndistTag=$([[ ${VERSION} == pre* ]] && echo \"--tag=next\" || echo \"\")\naccess=$([[ ${PUBLISH_ACCESS} = 'public' ]] && echo \"--access=public\" || echo \"--access=restricted\")\naccessMessage=$([[ ${PUBLISH_ACCESS} = 'public' ]] && echo \"public\" || echo \"private\")\ntagMessage=$([[ ${VERSION} == pre* ]] && echo \" with tag next\" || echo \"\")\n\necho \"Publishing new ${accessMessage} NPM module version${tagMessage}\"\n# Cannot use double quoting because of a bug in npm that assumes the \"\" as input\n# shellcheck disable=SC2086\nnpm publish ${distTag} ${access}\n"
       - name: Delete Branch
         # Delete remote branch may fail if repo is configured to automatically delete head branches.
         continue-on-error: true
         env:
-          BRANCH:  ${{ github.event.pull_request.head.ref }}
+          BRANCH: ${{ github.event.pull_request.head.ref }}
         run: |
           git push origin --delete "${BRANCH}" || true
+    permissions:
+      id-token: write
+      contents: read

--- a/.github/workflows/reusable_cicd-npm-package-publish.yml
+++ b/.github/workflows/reusable_cicd-npm-package-publish.yml
@@ -36,6 +36,9 @@ on:
 jobs:
   package-publish:
     runs-on: ${{ inputs.runner }}
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Validate token configuration
         if: ${{ !inputs.use_trusted_publisher }}
@@ -158,6 +161,3 @@ jobs:
           BRANCH: ${{ github.event.pull_request.head.ref }}
         run: |
           git push origin --delete "${BRANCH}" || true
-    permissions:
-      id-token: write
-      contents: read

--- a/.github/workflows/reusable_cicd-npm-package-publish.yml
+++ b/.github/workflows/reusable_cicd-npm-package-publish.yml
@@ -75,7 +75,24 @@ jobs:
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
         with:
-          script: "const fs = require('fs');\nif (!fs.existsSync('CHANGELOG.md')) {\n  core.info('Repository without CHANGELOG.md');\n  return;\n  \n}\n\nconst regexp = /##\\s\\[Unreleased\\](\\n|###\\s.*|-\\s.*)+/\nconst current = fs.readFileSync('CHANGELOG.md', 'utf8');\nif (regexp.test(current) ) {\n  const updated = current.replace(regexp, `## [Unreleased]\\n\\n### Changed\\n\\n- ${process.env.PR_TITLE}\\n\\n`)\n\n  fs.writeFileSync('CHANGELOG.md', updated)\n  await exec.exec(\"git\", [\"commit\", \"-a\", \"-m 'Update CHANGELOG'\",\"--no-verify\"])\n} else {\n  core.info(\"Changelog doesn't follow the expected format : ${regexp}\")\n}\n"
+          script: |
+            const fs = require('fs');
+            if (!fs.existsSync('CHANGELOG.md')) {
+              core.info('Repository without CHANGELOG.md');
+              return;
+              
+            }
+            
+            const regexp = /##\s\[Unreleased\](\n|###\s.*|-\s.*)+/
+            const current = fs.readFileSync('CHANGELOG.md', 'utf8');
+            if (regexp.test(current) ) {
+              const updated = current.replace(regexp, `## [Unreleased]\n\n### Changed\n\n- ${process.env.PR_TITLE}\n\n`)
+            
+              fs.writeFileSync('CHANGELOG.md', updated)
+              await exec.exec("git", ["commit", "-a", "-m 'Update CHANGELOG'","--no-verify"])
+            } else {
+              core.info("Changelog doesn't follow the expected format : ${regexp}")
+            }
       - name: Bump Version
         id: bump-version
         env:
@@ -118,9 +135,25 @@ jobs:
           VERSION: ${{ steps.bump-version.outputs.version }}
           REPO: ${{ github.repository }}
           GITHUB_TOKEN: ${{ steps.get-workflow-token.outputs.token }}
-        run: "git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/${REPO}.git\nif ! git push origin \"${GITHUB_BASE_REF}\" --tags --no-verify\nthen\n    echo \"Deleting ${VERSION} tag from remote.\"\n    git push --delete origin \"${VERSION}\"\n    \n    _errorMessage=\"\n    Failed to push to origin branch ${GITHUB_BASE_REF}.\n    Please check branch protection configuration in GitHub https://github.com/pipedrive/${params.REPO_NAME}/settings/branches\n    See https://pipedrive.atlassian.net/wiki/spaces/SD/pages/231178497/How+to+publish+NPM+modules#HowtopublishNPMmodules-Setup for more details.\n    \"\n  \n    echo \"::error::${_errorMessage}\"\n    exit 1\nfi\n"
+        run: |
+          git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/${REPO}.git
+          if ! git push origin "${GITHUB_BASE_REF}" --tags --no-verify
+          then
+              echo "Deleting ${VERSION} tag from remote."
+              git push --delete origin "${VERSION}"
+              
+              _errorMessage="
+              Failed to push to origin branch ${GITHUB_BASE_REF}.
+              Please check branch protection configuration in GitHub https://github.com/pipedrive/${params.REPO_NAME}/settings/branches
+              See https://pipedrive.atlassian.net/wiki/spaces/SD/pages/231178497/How+to+publish+NPM+modules#HowtopublishNPMmodules-Setup for more details.
+              "
+            
+              echo "::error::${_errorMessage}"
+              exit 1
+          fi
       - name: Create .npmrc for publishing
         shell: bash
+        if: ${{ !inputs.use_trusted_publisher }}
         run: |
           {
             #  For multiple registry we need to add the registry to the .npmrc
@@ -131,7 +164,7 @@ jobs:
             echo "@pipedrive:registry=https://registry.npmjs.org"
             echo "always-auth=true"
           } > .npmrc
-        if: ${{ !inputs.use_trusted_publisher }}
+
       - name: Read package.json
         id: read-package-json
         shell: bash
@@ -153,7 +186,17 @@ jobs:
           timeout_seconds: ${{ inputs.publish_timeout_seconds }}
           max_attempts: 3
           shell: bash
-          command: "# shellcheck disable=SC2016      \ndistTag=$([[ ${VERSION} == pre* ]] && echo \"--tag=next\" || echo \"\")\naccess=$([[ ${PUBLISH_ACCESS} = 'public' ]] && echo \"--access=public\" || echo \"--access=restricted\")\naccessMessage=$([[ ${PUBLISH_ACCESS} = 'public' ]] && echo \"public\" || echo \"private\")\ntagMessage=$([[ ${VERSION} == pre* ]] && echo \" with tag next\" || echo \"\")\n\necho \"Publishing new ${accessMessage} NPM module version${tagMessage}\"\n# Cannot use double quoting because of a bug in npm that assumes the \"\" as input\n# shellcheck disable=SC2086\nnpm publish ${distTag} ${access}\n"
+          command: |
+            # shellcheck disable=SC2016      
+            distTag=$([[ ${VERSION} == pre* ]] && echo "--tag=next" || echo "")
+            access=$([[ ${PUBLISH_ACCESS} = 'public' ]] && echo "--access=public" || echo "--access=restricted")
+            accessMessage=$([[ ${PUBLISH_ACCESS} = 'public' ]] && echo "public" || echo "private")
+            tagMessage=$([[ ${VERSION} == pre* ]] && echo " with tag next" || echo "")
+            
+            echo "Publishing new ${accessMessage} NPM module version${tagMessage}"
+            # Cannot use double quoting because of a bug in npm that assumes the "" as input
+            # shellcheck disable=SC2086
+            npm publish ${distTag} ${access}
       - name: Delete Branch
         # Delete remote branch may fail if repo is configured to automatically delete head branches.
         continue-on-error: true

--- a/.github/workflows/reusable_cicd-npm-package-publish.yml
+++ b/.github/workflows/reusable_cicd-npm-package-publish.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Set Git Config
         uses: ./gha-setup/actions/set-git-config-gha
       - name: Setup Node.js
-        uses: pipedrive-actions/github-actions-workflows/actions/setup-node@master
+        uses: pipedrive-actions/github-actions-workflows/actions/setup-node@CICDL-258-use-trusted-providers
       - name: Add Changelog Record
         if: ${{github.event.pull_request.user.login == 'dependabot[bot]'}}
         uses: actions/github-script@v9

--- a/.github/workflows/reusable_cicd-npm-package-publish.yml
+++ b/.github/workflows/reusable_cicd-npm-package-publish.yml
@@ -37,6 +37,15 @@ jobs:
   package-publish:
     runs-on: ${{ inputs.runner }}
     steps:
+      - name: Validate token configuration
+        if: ${{ !inputs.use_trusted_publisher }}
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_PUBLIC_PUBLISH_TOKEN }}
+        run: |
+          if [ -z "${NPM_TOKEN}" ]; then
+            echo "::error::NPM_PUBLIC_PUBLISH_TOKEN secret must be provided when use_trusted_publisher is false"
+            exit 1
+          fi
       - name: Checkout ${{ github.repository }}
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/reusable_cicd-npm-package-publish.yml
+++ b/.github/workflows/reusable_cicd-npm-package-publish.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Set Git Config
         uses: ./gha-setup/actions/set-git-config-gha
       - name: Setup Node.js
-        uses: pipedrive-actions/github-actions-workflows/actions/setup-node@CICDL-258-use-trusted-providers
+        uses: pipedrive-actions/github-actions-workflows/actions/setup-node@master
       - name: Add Changelog Record
         if: ${{github.event.pull_request.user.login == 'dependabot[bot]'}}
         uses: actions/github-script@v9

--- a/.github/workflows/reusable_cicd-npm-package-publish.yml
+++ b/.github/workflows/reusable_cicd-npm-package-publish.yml
@@ -30,7 +30,7 @@ on:
     secrets:
       NPM_PUBLIC_PUBLISH_TOKEN:
         description: NPM token to use for publishing
-        required: true
+        required: false
       PD_PUBLIC_GHA_BOT_APPLICATION_PRIVATE_KEY_PEM:
         required: true
 jobs:
@@ -119,6 +119,7 @@ jobs:
             echo "@pipedrive:registry=https://registry.npmjs.org"
             echo "always-auth=true"
           } > .npmrc
+        if: ${{ !inputs.use_trusted_publisher }}
       - name: Read package.json
         id: read-package-json
         shell: bash
@@ -133,7 +134,7 @@ jobs:
       - name: Publish to NPM
         uses: pipedrive/gha-command-retry@v3
         env:
-          NPM_TOKEN: ${{ secrets.NPM_PUBLIC_PUBLISH_TOKEN }}
+          NPM_TOKEN: ${{ !inputs.use_trusted_publisher && secrets.NPM_PUBLIC_PUBLISH_TOKEN || '' }}
           VERSION: ${{ inputs.version }}
           PUBLISH_ACCESS: ${{ steps.read-package-json.outputs.publish_access }}
         with:

--- a/.github/workflows/reusable_cicd-npm-package-publish.yml
+++ b/.github/workflows/reusable_cicd-npm-package-publish.yml
@@ -109,7 +109,7 @@ jobs:
         uses: actions/create-github-app-token@v3
         id: get-workflow-token
         with:
-          client-id: ${{ vars.PD_PUBLIC_GHA_BOT_APPLICATION_ID }}
+          client-id: ${{ vars.PD_PUBLIC_GHA_BOT_CLIENT_ID }}
           private-key: ${{ secrets.PD_PUBLIC_GHA_BOT_APPLICATION_PRIVATE_KEY_PEM }}
           owner: ${{ github.repository_owner }}
       - name: Push to GitHub

--- a/.github/workflows/reusable_cicd-npm-package-test.yml
+++ b/.github/workflows/reusable_cicd-npm-package-test.yml
@@ -71,7 +71,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Platform
-        uses: pipedrive-actions/github-actions-workflows/actions/setup-node@master
+        uses: pipedrive-actions/github-actions-workflows/actions/setup-node@CICDL-258-use-trusted-providers
 
       - name: Checkout gha-setup
         uses: actions/checkout@v6
@@ -124,7 +124,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Platform
-        uses: pipedrive-actions/github-actions-workflows/actions/setup-node@master
+        uses: pipedrive-actions/github-actions-workflows/actions/setup-node@CICDL-258-use-trusted-providers
         with:
           node_version: ${{ matrix.version }}
 

--- a/.github/workflows/reusable_cicd-npm-package-test.yml
+++ b/.github/workflows/reusable_cicd-npm-package-test.yml
@@ -37,7 +37,7 @@ jobs:
       other_supported_versions: ${{ steps.set-versions.outputs.other_supported_versions }}
     steps:
       - name: Checkout ${{ github.repository }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.revision }}
 
@@ -65,7 +65,7 @@ jobs:
     timeout-minutes: ${{ inputs.timeout_minutes }}
     steps:
       - name: Checkout ${{ github.repository }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.revision }}
           persist-credentials: false
@@ -74,7 +74,7 @@ jobs:
         uses: pipedrive-actions/github-actions-workflows/actions/setup-node@master
 
       - name: Checkout gha-setup
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: pipedrive/gha-setup
           path: gha-setup
@@ -118,7 +118,7 @@ jobs:
     runs-on: ${{ inputs.runner }}
     steps:
       - name: Checkout ${{ github.repository }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.revision }}
           persist-credentials: false
@@ -129,7 +129,7 @@ jobs:
           node_version: ${{ matrix.version }}
 
       - name: Checkout gha-setup
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: pipedrive/gha-setup
           path: gha-setup

--- a/.github/workflows/reusable_cicd-npm-package-test.yml
+++ b/.github/workflows/reusable_cicd-npm-package-test.yml
@@ -71,7 +71,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Platform
-        uses: pipedrive-actions/github-actions-workflows/actions/setup-node@CICDL-258-use-trusted-providers
+        uses: pipedrive-actions/github-actions-workflows/actions/setup-node@master
 
       - name: Checkout gha-setup
         uses: actions/checkout@v6
@@ -124,7 +124,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Platform
-        uses: pipedrive-actions/github-actions-workflows/actions/setup-node@CICDL-258-use-trusted-providers
+        uses: pipedrive-actions/github-actions-workflows/actions/setup-node@master
         with:
           node_version: ${{ matrix.version }}
 

--- a/.github/workflows/reusable_cicd-npm-publish.yml
+++ b/.github/workflows/reusable_cicd-npm-publish.yml
@@ -62,7 +62,7 @@ jobs:
       - package-test
       - package-checks
     name: Package Publish
-    uses: pipedrive-actions/github-actions-workflows/.github/workflows/reusable_cicd-npm-package-publish.yml@master
+    uses: pipedrive-actions/github-actions-workflows/.github/workflows/reusable_cicd-npm-package-publish.yml@CICDL-258-use-trusted-providers
     with:
       revision: ${{inputs.revision }}
       version: ${{ needs.package-checks.outputs.version }}

--- a/.github/workflows/reusable_cicd-npm-publish.yml
+++ b/.github/workflows/reusable_cicd-npm-publish.yml
@@ -41,7 +41,7 @@ env:
 jobs:
   package-checks:
     name: Package Checks
-    uses: pipedrive-actions/github-actions-workflows/.github/workflows/reusable_cicd-npm-package-checks.yml@CICDL-258-use-trusted-providers
+    uses: pipedrive-actions/github-actions-workflows/.github/workflows/reusable_cicd-npm-package-checks.yml@master
     with:
       revision: ${{ inputs.revision }}
       runner: ${{ inputs.runner }}
@@ -49,7 +49,7 @@ jobs:
   package-test:
     needs: package-checks
     name: Package Test
-    uses: pipedrive-actions/github-actions-workflows/.github/workflows/reusable_cicd-npm-package-test.yml@CICDL-258-use-trusted-providers
+    uses: pipedrive-actions/github-actions-workflows/.github/workflows/reusable_cicd-npm-package-test.yml@master
     with:
       revision: ${{ needs.package-checks.outputs.revision }}
       supported_versions: ${{ inputs.supported_versions }}
@@ -65,7 +65,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
-    uses: pipedrive-actions/github-actions-workflows/.github/workflows/reusable_cicd-npm-package-publish.yml@CICDL-258-use-trusted-providers
+    uses: pipedrive-actions/github-actions-workflows/.github/workflows/reusable_cicd-npm-package-publish.yml@master
     with:
       revision: ${{inputs.revision }}
       version: ${{ needs.package-checks.outputs.version }}

--- a/.github/workflows/reusable_cicd-npm-publish.yml
+++ b/.github/workflows/reusable_cicd-npm-publish.yml
@@ -31,18 +31,21 @@ on:
         type: string
         required: false
         default: ubuntu-latest
+      use_trusted_publisher:
+        description: Use NPM Trusted Publishers (OIDC) instead of NPM token. Requires trusted publisher registered on npmjs.com.
+        type: boolean
+        required: false
+        default: false
 env:
   platform: node
-
 jobs:
   package-checks:
-    name : Package Checks
+    name: Package Checks
     uses: pipedrive-actions/github-actions-workflows/.github/workflows/reusable_cicd-npm-package-checks.yml@master
     with:
       revision: ${{ inputs.revision }}
       runner: ${{ inputs.runner }}
     secrets: inherit
-
   package-test:
     needs: package-checks
     name: Package Test
@@ -54,7 +57,6 @@ jobs:
       timeout_minutes: ${{ inputs.timeout_minutes }}
       runner: ${{ inputs.runner }}
     secrets: inherit
-
   package-publish:
     needs:
       - package-test
@@ -66,4 +68,5 @@ jobs:
       version: ${{ needs.package-checks.outputs.version }}
       runner: ${{ inputs.runner }}
       publish_timeout_seconds: ${{ inputs.publish_timeout_seconds }}
+      use_trusted_publisher: ${{ inputs.use_trusted_publisher }}
     secrets: inherit

--- a/.github/workflows/reusable_cicd-npm-publish.yml
+++ b/.github/workflows/reusable_cicd-npm-publish.yml
@@ -65,7 +65,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
-    uses: pipedrive-actions/github-actions-workflows/.github/workflows/reusable_cicd-npm-package-publish.yml@CICDL-258-use-trusted-providers
+    uses: pipedrive-actions/github-actions-workflows/.github/workflows/reusable_cicd-npm-package-publish.yml@master
     with:
       revision: ${{inputs.revision }}
       version: ${{ needs.package-checks.outputs.version }}

--- a/.github/workflows/reusable_cicd-npm-publish.yml
+++ b/.github/workflows/reusable_cicd-npm-publish.yml
@@ -41,7 +41,7 @@ env:
 jobs:
   package-checks:
     name: Package Checks
-    uses: pipedrive-actions/github-actions-workflows/.github/workflows/reusable_cicd-npm-package-checks.yml@master
+    uses: pipedrive-actions/github-actions-workflows/.github/workflows/reusable_cicd-npm-package-checks.yml@CICDL-258-use-trusted-providers
     with:
       revision: ${{ inputs.revision }}
       runner: ${{ inputs.runner }}
@@ -49,7 +49,7 @@ jobs:
   package-test:
     needs: package-checks
     name: Package Test
-    uses: pipedrive-actions/github-actions-workflows/.github/workflows/reusable_cicd-npm-package-test.yml@master
+    uses: pipedrive-actions/github-actions-workflows/.github/workflows/reusable_cicd-npm-package-test.yml@CICDL-258-use-trusted-providers
     with:
       revision: ${{ needs.package-checks.outputs.revision }}
       supported_versions: ${{ inputs.supported_versions }}
@@ -65,7 +65,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
-    uses: pipedrive-actions/github-actions-workflows/.github/workflows/reusable_cicd-npm-package-publish.yml@master
+    uses: pipedrive-actions/github-actions-workflows/.github/workflows/reusable_cicd-npm-package-publish.yml@CICDL-258-use-trusted-providers
     with:
       revision: ${{inputs.revision }}
       version: ${{ needs.package-checks.outputs.version }}

--- a/.github/workflows/reusable_cicd-npm-publish.yml
+++ b/.github/workflows/reusable_cicd-npm-publish.yml
@@ -62,6 +62,9 @@ jobs:
       - package-test
       - package-checks
     name: Package Publish
+    permissions:
+      id-token: write
+      contents: read
     uses: pipedrive-actions/github-actions-workflows/.github/workflows/reusable_cicd-npm-package-publish.yml@CICDL-258-use-trusted-providers
     with:
       revision: ${{inputs.revision }}

--- a/actions/setup-node/action.yml
+++ b/actions/setup-node/action.yml
@@ -20,7 +20,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup Node
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version-file: ${{ inputs.directory }}.nvmrc
         node-version: ${{ inputs.node_version }}
@@ -30,7 +30,7 @@ runs:
     - name: Use node_modules cache
       if: inputs.ignore-scripts == 'true'
       id: cache-node-modules
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ${{ inputs.directory }}node_modules
         key: node-modules-${{ runner.os }}-${{ inputs.node_version || '' }}-${{ hashFiles('**/package-lock.json') }}
@@ -54,7 +54,7 @@ runs:
 
     - name: Setup Cache cypress
       if: ${{ steps.validation-cypress.outputs.valid == 'true'}}
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ${{steps.validation-cypress.outputs.path}}/${{ steps.validation-cypress.outputs.version }}
         key: cypress-${{ runner.os }}-${{ steps.validation-cypress.outputs.version }}
@@ -86,7 +86,7 @@ runs:
 
     - name: Setup Cache jest
       if: ${{ steps.validation-jest.outputs.valid == 'true'}}
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ${{steps.validation-jest.outputs.path}}
         key: jest-cache-${{github.event.number}}


### PR DESCRIPTION
## Summary

- Adds \`use_trusted_publisher\` boolean input (default: \`false\`) to both \`reusable_cicd-npm-publish.yml\` and \`reusable_cicd-npm-package-publish.yml\`
- When \`true\`: skips \`.npmrc\` token setup, sets empty \`NPM_TOKEN\`, and uses OIDC via \`id-token: write\` permission — npm CLI authenticates automatically
- When \`false\` (default): existing token-based flow is completely unchanged; \`NPM_PUBLIC_PUBLISH_TOKEN\` is still used
- Adds early validation step to fail fast with a clear error if \`use_trusted_publisher: false\` but no token is provided
- Upgrades all GitHub Actions to Node 24-compatible versions: \`checkout@v6\`, \`setup-node@v6\`, \`cache@v5\`, \`github-script@v9\`, \`create-github-app-token@v3\` (also renames \`app-id\` → \`client-id\`)
- The var PD_PUBLIC_GHA_BOT_CLIENT_ID was created and added to the public repositories

## Migration (per package, after this merges)

1. Register a Trusted Publisher on npmjs.com for the package (owner + repo + workflow filename)
2. Add \`permissions: { id-token: write, contents: write, actions: write }\` to the calling job
3. Set \`use_trusted_publisher: true\` in the calling workflow
4. Remove \`NPM_PUBLIC_PUBLISH_TOKEN\` from repo secrets

Affected packages: \`client-nodejs\`, \`test-public-npm-module\`, \`app-extensions-sdk\`

## Manual test evidence

End-to-end publish via OIDC Trusted Publisher on Node 24 (npm 11.x): https://github.com/pipedrive/test-public-npm-module/actions/runs/26157207855

## Test plan

- [x] Verify existing token-based publish still works (no \`use_trusted_publisher\` set → default \`false\` path)
- [x] Register a Trusted Publisher on npmjs.com, set \`use_trusted_publisher: true\`, trigger publish — OIDC auth succeeds (see run above)
- [x] Confirm that passing \`use_trusted_publisher: false\` with no \`NPM_PUBLIC_PUBLISH_TOKEN\` fails at the validation step with a clear error
- [x] All upgraded actions run successfully on Node 24

🤖 Generated with [Claude Code](https://claude.com/claude-code)