### PR TITLE
CICDL-378: Remove unused NPM_PUBLIC_PUBLISH_TOKEN

### DIFF
--- a/.github/workflows/reusable_cicd-npm-package-publish.yml
+++ b/.github/workflows/reusable_cicd-npm-package-publish.yml
@@ -28,9 +28,6 @@ on:
         required: false
         default: false
     secrets:
-      NPM_PUBLIC_PUBLISH_TOKEN:
-        description: NPM token to use for publishing
-        required: false
       PD_PUBLIC_GHA_BOT_APPLICATION_PRIVATE_KEY_PEM:
         required: true
 jobs:
@@ -40,15 +37,6 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - name: Validate token configuration
-        if: ${{ !inputs.use_trusted_publisher }}
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_PUBLIC_PUBLISH_TOKEN }}
-        run: |
-          if [ -z "${NPM_TOKEN}" ]; then
-            echo "::error::NPM_PUBLIC_PUBLISH_TOKEN secret must be provided when use_trusted_publisher is false"
-            exit 1
-          fi
       - name: Checkout ${{ github.repository }}
         uses: actions/checkout@v6
         with:
@@ -151,20 +139,6 @@ jobs:
               echo "::error::${_errorMessage}"
               exit 1
           fi
-      - name: Create .npmrc for publishing
-        shell: bash
-        if: ${{ !inputs.use_trusted_publisher }}
-        run: |
-          {
-            #  For multiple registry we need to add the registry to the .npmrc
-            # https://sevic.dev/npm-publish-github-actions/
-            # NPM can expand enviroment variables, this we avoid write the token in the filesystem
-            # shellcheck disable=SC2016
-            echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}'
-            echo "@pipedrive:registry=https://registry.npmjs.org"
-            echo "always-auth=true"
-          } > .npmrc
-
       - name: Read package.json
         id: read-package-json
         shell: bash
@@ -179,8 +153,6 @@ jobs:
       - name: Publish to NPM
         uses: pipedrive/gha-command-retry@v3
         env:
-          ## Not set NPM_TOKEN when using trusted publisher because in that flow that token is not needed
-          NPM_TOKEN: ${{ !inputs.use_trusted_publisher && secrets.NPM_PUBLIC_PUBLISH_TOKEN || '' }}
           VERSION: ${{ inputs.version }}
           PUBLISH_ACCESS: ${{ steps.read-package-json.outputs.publish_access }}
         with:

--- a/.github/workflows/reusable_cicd-npm-package-publish.yml
+++ b/.github/workflows/reusable_cicd-npm-package-publish.yml
@@ -22,11 +22,6 @@ on:
         type: number
         default: 180
         required: false
-      use_trusted_publisher:
-        description: Use NPM Trusted Publishers (OIDC) instead of NPM token. Requires trusted publisher registered on npmjs.com.
-        type: boolean
-        required: false
-        default: false
     secrets:
       PD_PUBLIC_GHA_BOT_APPLICATION_PRIVATE_KEY_PEM:
         required: true

--- a/.github/workflows/reusable_cicd-npm-publish.yml
+++ b/.github/workflows/reusable_cicd-npm-publish.yml
@@ -60,7 +60,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
-    uses: pipedrive-actions/github-actions-workflows/.github/workflows/reusable_cicd-npm-package-publish.yml@master
+    uses: pipedrive-actions/github-actions-workflows/.github/workflows/reusable_cicd-npm-package-publish.yml@CICDL-378-remove-npm-public-publish-token
     with:
       revision: ${{inputs.revision }}
       version: ${{ needs.package-checks.outputs.version }}

--- a/.github/workflows/reusable_cicd-npm-publish.yml
+++ b/.github/workflows/reusable_cicd-npm-publish.yml
@@ -31,11 +31,6 @@ on:
         type: string
         required: false
         default: ubuntu-latest
-      use_trusted_publisher:
-        description: Use NPM Trusted Publishers (OIDC) instead of NPM token. Requires trusted publisher registered on npmjs.com.
-        type: boolean
-        required: false
-        default: false
 env:
   platform: node
 jobs:
@@ -71,5 +66,4 @@ jobs:
       version: ${{ needs.package-checks.outputs.version }}
       runner: ${{ inputs.runner }}
       publish_timeout_seconds: ${{ inputs.publish_timeout_seconds }}
-      use_trusted_publisher: ${{ inputs.use_trusted_publisher }}
     secrets: inherit

--- a/.github/workflows/reusable_cicd-npm-publish.yml
+++ b/.github/workflows/reusable_cicd-npm-publish.yml
@@ -60,7 +60,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
-    uses: pipedrive-actions/github-actions-workflows/.github/workflows/reusable_cicd-npm-package-publish.yml@CICDL-378-remove-npm-public-publish-token
+    uses: pipedrive-actions/github-actions-workflows/.github/workflows/reusable_cicd-npm-package-publish.yml@master
     with:
       revision: ${{inputs.revision }}
       version: ${{ needs.package-checks.outputs.version }}


### PR DESCRIPTION
## Summary

After completing [CICDL-258](https://pipedrive.atlassian.net/browse/CICDL-258) (migrate npm publishing to OIDC Trusted Publishers), the `NPM_PUBLIC_PUBLISH_TOKEN` secret and `use_trusted_publisher` input are no longer needed. This PR removes the token-based publish code path entirely, making OIDC the only publish method.

**All 4 public package repos have PRs to stop passing `use_trusted_publisher`:**
- `pipedrive/create-pipedrive-app` — https://github.com/pipedrive/create-pipedrive-app/pull/24
- `pipedrive/client-nodejs` — https://github.com/pipedrive/client-nodejs/pull/739
- `pipedrive/app-extensions-sdk` — https://github.com/pipedrive/app-extensions-sdk/pull/72
- `pipedrive/test-public-npm-module` — https://github.com/pipedrive/test-public-npm-module/pull/31

**⚠️ Merge order: merge the 4 caller PRs above FIRST, then this PR.** Removing the `use_trusted_publisher` input before callers stop passing it would break their workflows.

**What's removed:**
- `NPM_PUBLIC_PUBLISH_TOKEN` secret input
- `use_trusted_publisher` input (from both wrapper and inner workflow)
- "Validate token configuration" step
- "Create .npmrc for publishing" step (token-based auth config)
- `NPM_TOKEN` env var from the "Publish to NPM" step
- Pass-through of `use_trusted_publisher` in the wrapper workflow

## Tested

Verified end-to-end in https://github.com/pipedrive/test-public-npm-module/pull/32 — publish workflow pointed to this feature branch (both wrapper and inner workflow), with `use_trusted_publisher` removed from the caller.

**Result:** `@pipedrive/test-public-npm-module@1.0.19` published successfully via OIDC with signed provenance ([run logs](https://github.com/pipedrive/test-public-npm-module/actions/runs/27551977187)):
- No `NPM_PUBLIC_PUBLISH_TOKEN` used
- No `.npmrc` token auth created
- No `Validate token configuration` step ran
- `npm notice publish Signed provenance statement with source and build information from GitHub Actions`
- `Provenance statement published to transparency log: https://search.sigstore.dev/?logIndex=1825288959`

## Remaining cleanup (outside this repo)

Per [CICDL-378](https://pipedrive.atlassian.net/browse/CICDL-378):
- Remove `NPM_PUBLIC_PUBLISH_TOKEN` from GitHub Actions org-level secrets
- Revoke the corresponding token on npmjs.org for `pipedrive-github-publish-bot`
- Remove the secret entry from Keeper